### PR TITLE
Sets the state to be enabled on offer creation

### DIFF
--- a/app/models/concerns/offers/state_handler.rb
+++ b/app/models/concerns/offers/state_handler.rb
@@ -6,11 +6,7 @@ module Offers
 
     included do
       def toggle_state
-        self[:enabled] = disabled? ? true : false
-      end
-
-      def disabled?
-        self[:enabled] == false
+        self[:enabled] = !self[:enabled]
       end
 
       def not_started?

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -19,9 +19,9 @@ class Offer < ApplicationRecord
   end
 
   def enabled?
-    return false if disabled? || not_started? || finished?
+    return false if not_started? || finished?
 
-    true
+    self[:enabled]
   end
 
   private

--- a/db/migrate/20200408173000_add_enabled_to_offer.rb
+++ b/db/migrate/20200408173000_add_enabled_to_offer.rb
@@ -1,5 +1,5 @@
 class AddEnabledToOffer < ActiveRecord::Migration[6.0]
   def change
-    add_column :offers, :enabled, :boolean, null: true
+    add_column :offers, :enabled, :boolean, default: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -24,7 +24,7 @@ ActiveRecord::Schema.define(version: 2020_04_08_173000) do
     t.boolean "premium"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.boolean "enabled"
+    t.boolean "enabled", default: true
     t.index ["advertiser_name"], name: "index_offers_on_advertiser_name", unique: true
   end
 

--- a/spec/factories/offers.rb
+++ b/spec/factories/offers.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     description { Faker::Lorem.paragraph_by_chars(number: 500, supplemental: false) }
     starts_at { Date.current }
     ends_at { Date.current + 10.days }
-    enabled { nil }
+    enabled { true }
     premium { false }
 
     trait :premium do

--- a/spec/models/offer_spec.rb
+++ b/spec/models/offer_spec.rb
@@ -53,7 +53,7 @@ describe Offer do
     end
 
     context 'if admin didnt explicit disabled the offer' do
-      let(:offer) { create(:offer, enabled: nil) }
+      let(:offer) { create(:offer) }
       context 'it will disables it' do
         it { is_expected.to be false }
       end
@@ -92,7 +92,7 @@ describe Offer do
         end
 
         context 'and isnt ended yet' do
-          let(:offer) { create(:offer, enabled: nil) }
+          let(:offer) { create(:offer) }
 
           it { is_expected.to be true }
         end
@@ -145,21 +145,6 @@ describe Offer do
       let(:offer) { create(:offer, starts_at: Date.current + 1.day) }
 
       it { is_expected.to be true }
-    end
-  end
-
-  describe '#disabled?' do
-    subject { offer.disabled? }
-    context 'if admin disabled the offer' do
-      let(:offer) { create(:offer, :disabled) }
-
-      it { is_expected.to be true }
-    end
-
-    context 'if admin didnt explicit disabled the offer' do
-      let(:offer) { create(:offer, enabled: nil) }
-
-      it { is_expected.to be false }
     end
   end
 end


### PR DESCRIPTION
### WHY
The front is getting problems to fetch all Offers based on the business rules;

### HOW
- To simplify the query and to remove unnecessary complexity, the offer will be created enabled!
- - Even the offer being created as enabled, the time rules are looked before of it!